### PR TITLE
Pin Tailwind to 3.4.19 in dashboard workspace to avoid native binding errors

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,5 +1,11 @@
 {
   "name": "dmbs-dashboard",
   "private": true,
-  "workspaces": ["backend", "frontend"]
+  "workspaces": [
+    "backend",
+    "frontend"
+  ],
+  "overrides": {
+    "tailwindcss": "3.4.19"
+  }
 }


### PR DESCRIPTION
### Motivation
- Prevent accidental resolution to Tailwind v4 (which pulls `@tailwindcss/oxide` with optional native bindings) that can trigger npm optional-dependency install failures on some environments (notably Windows/npm bug).

### Description
- Add an `overrides` entry in `dashboard/package.json` to force `tailwindcss` to `3.4.19` (`"overrides": { "tailwindcss": "3.4.19" }`).

### Testing
- Ran `cd /workspace/dmbs-scraper/dashboard && npm install` (succeeded) and `cd /workspace/dmbs-scraper/dashboard && npm run build --workspace=frontend` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae9006edd0832a9ce226bde4c530a9)